### PR TITLE
-e should be -d in example usage

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,7 +18,7 @@ Then use your debugger like normal:
 
 If you don't want a `$HOME/.perldb` file, you can do this:
 
-    perl -MDB::Color -e some_file.pl
+    perl -MDB::Color -d some_file.pl
 
 # DISABLING COLOR
 

--- a/lib/DB/Color.pm
+++ b/lib/DB/Color.pm
@@ -35,7 +35,7 @@ Then use your debugger like normal:
 
 If you don't want a F<$HOME/.perldb> file, you can do this:
 
- perl -MDB::Color -e some_file.pl
+ perl -MDB::Color -d some_file.pl
 
 =head1 DISABLING COLOR
 


### PR DESCRIPTION
This does not work for me:
perl -MDB::Color -e app.pl

This does:
perl -MDB::Color -d app.pl

I updated the examples in lib/DB/Color.pm and README.markdown to use -d to match the example in the README. If it is supposed to be -e then I might have found a bug.
